### PR TITLE
Update zsh prompt and add release skill

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: release
+description: "Complete a GitHub release branch cycle for a non-primary branch: push the current or named branch, create a pull request into master, merge it with remote branch deletion, update local master, delete the old local branch, and recreate that same branch from the latest master. Use when the user asks to finish a branch-to-master PR/merge cycle and reset the working branch for the next cycle."
+---
+
+# Release
+
+## Overview
+
+Complete one full GitHub branch cycle:
+
+1. Push `branch-x` to `origin`.
+2. Create a PR from `branch-x` into `master`.
+3. Merge the PR and delete the remote branch.
+4. Update local `master`.
+5. Delete the old local `branch-x`.
+6. Recreate `branch-x` from the latest `master`.
+
+Use `branch-x` as the branch requested by the user. If no branch is named, use the current branch. Do not use this workflow from `master` itself.
+
+## Preconditions
+
+- Confirm the repository is clean before mutating anything:
+
+```bash
+git status --short --branch
+```
+
+- Confirm the target branch:
+
+```bash
+git branch --show-current
+```
+
+- Stop and ask before proceeding if:
+  - the working tree has uncommitted changes,
+  - the branch is `master`,
+  - the PR is not mergeable,
+  - CI, branch protection, or GitHub permissions block the merge.
+
+## Workflow
+
+Replace `branch-x` with the actual branch name and keep `master` as the base branch unless the user explicitly requests another base.
+
+1. Push the branch:
+
+```bash
+git push origin branch-x
+```
+
+2. Create the PR:
+
+```bash
+gh pr create --base master --head branch-x --title "<concise title>" --body "<summary and verification>"
+```
+
+3. Capture the PR number from the output, then verify the PR:
+
+```bash
+gh pr view <PR_NUMBER> --json number,baseRefName,headRefName,state,isDraft,mergeable,url
+```
+
+Proceed only when `baseRefName` is `master`, `headRefName` is `branch-x`, `state` is `OPEN`, and `mergeable` is `MERGEABLE`.
+
+4. Merge with a merge commit and delete the remote branch:
+
+```bash
+gh pr merge <PR_NUMBER> --merge --delete-branch
+```
+
+5. Ensure local `master` is current:
+
+```bash
+git checkout master
+git pull --ff-only origin master
+```
+
+6. Delete the old local branch if it still exists:
+
+```bash
+git branch --list branch-x
+git branch -d branch-x
+```
+
+If `gh pr merge --delete-branch` already deleted the local branch, skip `git branch -d branch-x`.
+
+7. Recreate the branch from latest `master`:
+
+```bash
+git checkout -b branch-x
+```
+
+## Verification
+
+Run these checks after recreating the branch:
+
+```bash
+git branch --show-current
+git log --oneline master..branch-x
+git ls-remote --heads origin branch-x
+git status --short --branch
+gh pr view <PR_NUMBER> --json state,mergedAt,mergeCommit,url
+```
+
+Expected results:
+
+- Current branch is `branch-x`.
+- `git log --oneline master..branch-x` is empty.
+- `git ls-remote --heads origin branch-x` is empty.
+- Worktree is clean.
+- PR state is `MERGED`.
+
+## Reporting
+
+Summarize the completed cycle with:
+
+- PR URL and PR number.
+- Merge commit SHA.
+- Current branch.
+- Whether remote `branch-x` is deleted.
+- Whether local `branch-x` was recreated from latest `master`.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "Complete a GitHub release branch cycle for a non-primary branch: push the current or named branch, create a pull request into master, merge it with remote branch deletion, update local master, delete the old local branch, and recreate that same branch from the latest master. Use when the user asks to finish a branch-to-master PR/merge cycle and reset the working branch for the next cycle."
+description: "Complete a GitHub release branch cycle for a non-primary branch: detect the repository default branch, push the current or named branch, create a pull request into the default branch, merge it with remote branch deletion, update the local default branch, delete the old local branch, and recreate that same branch from the latest default branch. Use when the user asks to finish a branch-to-default-branch PR/merge cycle and reset the working branch for the next cycle."
 ---
 
 # Release
@@ -10,13 +10,13 @@ description: "Complete a GitHub release branch cycle for a non-primary branch: p
 Complete one full GitHub branch cycle:
 
 1. Push `branch-x` to `origin`.
-2. Create a PR from `branch-x` into `master`.
+2. Create a PR from `branch-x` into the repository default branch.
 3. Merge the PR and delete the remote branch.
-4. Update local `master`.
+4. Update the local default branch.
 5. Delete the old local `branch-x`.
-6. Recreate `branch-x` from the latest `master`.
+6. Recreate `branch-x` from the latest default branch.
 
-Use `branch-x` as the branch requested by the user. If no branch is named, use the current branch. Do not use this workflow from `master` itself.
+Use `branch-x` as the branch requested by the user. If no branch is named, use the current branch. Detect the repository default branch and do not use this workflow from that branch itself.
 
 ## Preconditions
 
@@ -32,15 +32,24 @@ git status --short --branch
 git branch --show-current
 ```
 
+- Detect the default branch from `origin`:
+
+```bash
+base_branch=$(git remote show origin | sed -n 's/.*HEAD branch: //p')
+test -n "$base_branch"
+```
+
+Use `base_branch` as the base branch. Stop and ask before proceeding if the default branch cannot be detected.
+
 - Stop and ask before proceeding if:
   - the working tree has uncommitted changes,
-  - the branch is `master`,
+  - the branch is `$base_branch`,
   - the PR is not mergeable,
   - CI, branch protection, or GitHub permissions block the merge.
 
 ## Workflow
 
-Replace `branch-x` with the actual branch name and keep `master` as the base branch unless the user explicitly requests another base.
+Replace `branch-x` with the actual branch name. Use `$base_branch` as the detected default branch unless the user explicitly requests another base.
 
 1. Push the branch:
 
@@ -51,7 +60,7 @@ git push origin branch-x
 2. Create the PR:
 
 ```bash
-gh pr create --base master --head branch-x --title "<concise title>" --body "<summary and verification>"
+gh pr create --base "$base_branch" --head branch-x --title "<concise title>" --body "<summary and verification>"
 ```
 
 3. Capture the PR number from the output, then verify the PR:
@@ -60,7 +69,7 @@ gh pr create --base master --head branch-x --title "<concise title>" --body "<su
 gh pr view <PR_NUMBER> --json number,baseRefName,headRefName,state,isDraft,mergeable,url
 ```
 
-Proceed only when `baseRefName` is `master`, `headRefName` is `branch-x`, `state` is `OPEN`, and `mergeable` is `MERGEABLE`.
+Proceed only when `baseRefName` matches `$base_branch`, `headRefName` is `branch-x`, `state` is `OPEN`, and `mergeable` is `MERGEABLE`.
 
 4. Merge with a merge commit and delete the remote branch:
 
@@ -68,11 +77,11 @@ Proceed only when `baseRefName` is `master`, `headRefName` is `branch-x`, `state
 gh pr merge <PR_NUMBER> --merge --delete-branch
 ```
 
-5. Ensure local `master` is current:
+5. Ensure the local default branch is current:
 
 ```bash
-git checkout master
-git pull --ff-only origin master
+git checkout "$base_branch"
+git pull --ff-only origin "$base_branch"
 ```
 
 6. Delete the old local branch if it still exists:
@@ -84,7 +93,7 @@ git branch -d branch-x
 
 If `gh pr merge --delete-branch` already deleted the local branch, skip `git branch -d branch-x`.
 
-7. Recreate the branch from latest `master`:
+7. Recreate the branch from the latest default branch:
 
 ```bash
 git checkout -b branch-x
@@ -96,7 +105,7 @@ Run these checks after recreating the branch:
 
 ```bash
 git branch --show-current
-git log --oneline master..branch-x
+git log --oneline "$base_branch..branch-x"
 git ls-remote --heads origin branch-x
 git status --short --branch
 gh pr view <PR_NUMBER> --json state,mergedAt,mergeCommit,url
@@ -105,7 +114,7 @@ gh pr view <PR_NUMBER> --json state,mergedAt,mergeCommit,url
 Expected results:
 
 - Current branch is `branch-x`.
-- `git log --oneline master..branch-x` is empty.
+- `git log --oneline "$base_branch..branch-x"` is empty.
 - `git ls-remote --heads origin branch-x` is empty.
 - Worktree is clean.
 - PR state is `MERGED`.
@@ -116,6 +125,7 @@ Summarize the completed cycle with:
 
 - PR URL and PR number.
 - Merge commit SHA.
+- Detected base branch.
 - Current branch.
 - Whether remote `branch-x` is deleted.
-- Whether local `branch-x` was recreated from latest `master`.
+- Whether local `branch-x` was recreated from the latest default branch.

--- a/.agents/skills/release/agents/openai.yaml
+++ b/.agents/skills/release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release"
   short_description: "Push, PR, merge, and refresh a branch"
-  default_prompt: "Use $release to merge the current branch into master and recreate it from the latest master."
+  default_prompt: "Use $release to merge the current branch into the default branch and recreate it from the latest default branch."

--- a/.agents/skills/release/agents/openai.yaml
+++ b/.agents/skills/release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release"
+  short_description: "Push, PR, merge, and refresh a branch"
+  default_prompt: "Use $release to merge the current branch into master and recreate it from the latest master."

--- a/.zsh/.zshrc/default.zsh
+++ b/.zsh/.zshrc/default.zsh
@@ -4,17 +4,67 @@
 #
 autoload colors
 colors
-case ${UID} in
-    0)
-        PROMPT="%{${fg[cyan]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') %B%{${fg[yellow]}%}%/#%{${reset_color}%}%b "
-        PROMPT2="%B%{${fg[yellow]}%}%_#%{${reset_color}%}%b "
-        SPROMPT="%B%{${fg[yellow]}%}%r is correct? [n,y,a,e]:%{${reset_color}%}%b "
+autoload -Uz vcs_info
+setopt prompt_subst
+
+case "${ZSH_COLOR_MODE}" in
+    light|dark)
         ;;
     *)
-        PROMPT="%{${fg[yellow]}%}%/%%%{${reset_color}%} "
-        PROMPT2="%{${fg[yellow]}%}%_%%%{${reset_color}%} "
-        SPROMPT="%{${fg[yellow]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
-        [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] && PROMPT="%{${fg[cyan]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') ${PROMPT}"
+        ZSH_COLOR_MODE=dark
+        ;;
+esac
+
+case "${ZSH_COLOR_MODE}" in
+    light)
+        zsh_prompt_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_prompt2_color=$'%{\e[38;2;0;0;0m\e[48;2;208;255;29m%}'
+        zsh_sprompt_color=$'%{\e[38;2;0;0;0m\e[48;2;208;255;29m%}'
+        zsh_host_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_root_prompt_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_git_branch_color=$'%{\e[38;2;208;255;29m\e[48;2;128;128;128m%}'
+        zsh_xterm_lscolors=exfxcxdxbxegedabagacadah
+        zsh_xterm_ls_colors='rs=0:fi=30:di=90:ln=37:so=90:pi=90:ex=38;2;208;255;29:bd=90:cd=90:su=38;2;208;255;29:sg=38;2;208;255;29:tw=90:ow=90'
+        zsh_xterm_list_colors=('fi=30' 'di=90' 'ln=37' 'so=90' 'pi=90' 'ex=38;2;208;255;29' 'bd=90' 'cd=90' 'su=38;2;208;255;29' 'sg=38;2;208;255;29' 'tw=90' 'ow=90')
+        zsh_cons25_lscolors=exfxcxdxbxegedabagacadah
+        zsh_cons25_ls_colors='rs=0:fi=30:di=90:ln=37:so=90:pi=90:ex=38;2;208;255;29:bd=90:cd=90:su=38;2;208;255;29:sg=38;2;208;255;29:tw=90:ow=90'
+        zsh_cons25_list_colors=('fi=30' 'di=90' 'ln=37' 'so=90' 'pi=90' 'ex=38;2;208;255;29' 'bd=90' 'cd=90' 'su=38;2;208;255;29' 'sg=38;2;208;255;29' 'tw=90' 'ow=90')
+        zsh_jfbterm_lscolors=exfxcxdxbxegedabagacadah
+        zsh_jfbterm_ls_colors='rs=0:fi=30:di=90:ln=37:so=90:pi=90:ex=38;2;208;255;29:bd=90:cd=90:su=38;2;208;255;29:sg=38;2;208;255;29:tw=90:ow=90'
+        zsh_jfbterm_list_colors=('fi=30' 'di=90' 'ln=37' 'so=90' 'pi=90' 'ex=38;2;208;255;29' 'bd=90' 'cd=90' 'su=38;2;208;255;29' 'sg=38;2;208;255;29' 'tw=90' 'ow=90')
+        ;;
+    dark)
+        zsh_prompt_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_prompt2_color=$'%{\e[38;2;0;0;0m\e[48;2;208;255;29m%}'
+        zsh_sprompt_color=$'%{\e[38;2;0;0;0m\e[48;2;208;255;29m%}'
+        zsh_host_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_root_prompt_color=$'%{\e[38;2;208;255;29m\e[48;2;64;64;64m%}'
+        zsh_git_branch_color=$'%{\e[38;2;208;255;29m\e[48;2;128;128;128m%}'
+        zsh_xterm_lscolors=exfxcxdxbxacadabafaggx
+        zsh_xterm_ls_colors='di=34:ln=35:so=32:pi=33:ex=31:bd=30;42:cd=30;43:su=30;41:sg=30;45:tw=30;46:ow=36'
+        zsh_xterm_list_colors=('di=34' 'ln=35' 'so=32' 'ex=31' 'bd=46;34' 'cd=43;34')
+        zsh_cons25_lscolors=ExFxCxdxBxegedabagacad
+        zsh_cons25_ls_colors='di=01;34:ln=01;35:so=01;32:ex=01;31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
+        zsh_cons25_list_colors=('di=;34;1' 'ln=;35;1' 'so=;32;1' 'ex=31;1' 'bd=46;34' 'cd=43;34')
+        zsh_jfbterm_lscolors=gxFxCxdxBxegedabagacad
+        zsh_jfbterm_ls_colors='di=01;36:ln=01;35:so=01;32:ex=01;31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
+        zsh_jfbterm_list_colors=('di=;36;1' 'ln=;35;1' 'so=;32;1' 'ex=31;1' 'bd=46;34' 'cd=43;34')
+        ;;
+esac
+
+zstyle ':vcs_info:git:*' formats "${zsh_git_branch_color} %b %{${reset_color}%}"
+
+case ${UID} in
+    0)
+        PROMPT="${zsh_host_color} $(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') %B${zsh_root_prompt_color}%~ %{${reset_color}%}%b"'${vcs_info_msg_0_}'" "
+        PROMPT2="%B${zsh_prompt2_color}%_#%{${reset_color}%}%b "
+        SPROMPT="%B${zsh_sprompt_color}%r is correct? [n,y,a,e]:%{${reset_color}%}%b "
+        ;;
+    *)
+        PROMPT="${zsh_host_color} %~ %{${reset_color}%}"'${vcs_info_msg_0_}'" "
+        PROMPT2="${zsh_prompt2_color}%_%%%{${reset_color}%} "
+        SPROMPT="${zsh_sprompt_color}%r is correct? [n,y,a,e]:%{${reset_color}%} "
+        [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] && PROMPT="${zsh_host_color}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]')${PROMPT}"
         ;;
 esac
 
@@ -131,39 +181,40 @@ esac
 ## generator
 # https://geoff.greer.fm/lscolors/
 case "${TERM}" in
-    xterm|xterm-color)
-        export LSCOLORS=exfxcxdxbxacadabafaggx
-        export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=30;42:cd=30;43:su=30;41:sg=30;45:tw=30;46:ow=36'
-        zstyle ':completion:*' list-colors 'di=34' 'ln=35' 'so=32' 'ex=31' 'bd=46;34' 'cd=43;34'
+    xterm|xterm-color|xterm-256color)
+        export LSCOLORS=${zsh_xterm_lscolors}
+        export LS_COLORS=${zsh_xterm_ls_colors}
+        zstyle ':completion:*' list-colors "${zsh_xterm_list_colors[@]}"
         ;;
     kterm-color)
         stty erase '^H'
-        export LSCOLORS=exfxcxdxbxacadabafaggx
-        export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=30;42:cd=30;43:su=30;41:sg=30;45:tw=30;46:ow=36'
-        zstyle ':completion:*' list-colors 'di=34' 'ln=35' 'so=32' 'ex=31' 'bd=46;34' 'cd=43;34'
+        export LSCOLORS=${zsh_xterm_lscolors}
+        export LS_COLORS=${zsh_xterm_ls_colors}
+        zstyle ':completion:*' list-colors "${zsh_xterm_list_colors[@]}"
         ;;
     kterm)
         stty erase '^H'
         ;;
     cons25)
         unset LANG
-        export LSCOLORS=ExFxCxdxBxegedabagacad
-        export LS_COLORS='di=01;34:ln=01;35:so=01;32:ex=01;31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
-        zstyle ':completion:*' list-colors 'di=;34;1' 'ln=;35;1' 'so=;32;1' 'ex=31;1' 'bd=46;34' 'cd=43;34'
+        export LSCOLORS=${zsh_cons25_lscolors}
+        export LS_COLORS=${zsh_cons25_ls_colors}
+        zstyle ':completion:*' list-colors "${zsh_cons25_list_colors[@]}"
         ;;
     jfbterm-color)
-        export LSCOLORS=gxFxCxdxBxegedabagacad
-        export LS_COLORS='di=01;36:ln=01;35:so=01;32:ex=01;31:bd=46;34:cd=43;34:su=41;30:sg=46;30:tw=42;30:ow=43;30'
-        zstyle ':completion:*' list-colors 'di=;36;1' 'ln=;35;1' 'so=;32;1' 'ex=31;1' 'bd=46;34' 'cd=43;34'
+        export LSCOLORS=${zsh_jfbterm_lscolors}
+        export LS_COLORS=${zsh_jfbterm_ls_colors}
+        zstyle ':completion:*' list-colors "${zsh_jfbterm_list_colors[@]}"
         ;;
 esac
 
 # set terminal title including current directory
 #
-case "${TERM}" in
-    xterm|xterm-color|kterm|kterm-color)
-        precmd() {
+precmd() {
+    vcs_info
+    case "${TERM}" in
+        xterm|xterm-color|xterm-256color|kterm|kterm-color)
             echo -ne "\033]0;${USER}@${HOST%%.*}:${PWD}\007"
-        }
-        ;;
-esac
+            ;;
+    esac
+}

--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,11 @@
+if [ -f ~/.zsh/.zshrc/theme.zsh ]; then
+  source ~/.zsh/.zshrc/theme.zsh
+fi
+
 source ~/.zsh/.zshrc/default.zsh
 
 for i in ~/.zsh/.zshrc/*.zsh; do
   [ $i = ~/.zsh/.zshrc/default.zsh ] && continue
+  [ $i = ~/.zsh/.zshrc/theme.zsh ] && continue
   source $i
 done


### PR DESCRIPTION
Summary: customize zsh prompt styling; add a reusable release skill; detect the repository default branch instead of assuming master. Verification: git status --short --branch; git log --oneline master..dev; git diff --stat master..dev.